### PR TITLE
Cached process.env.NODE_ENV access for performance

### DIFF
--- a/components/custom-head/index.js
+++ b/components/custom-head/index.js
@@ -1,3 +1,4 @@
+import { isDev } from 'env'
 import NextHead from 'next/head'
 
 export function CustomHead({ title = '', description, image, keywords }) {
@@ -9,7 +10,7 @@ export function CustomHead({ title = '', description, image, keywords }) {
         <meta
           name="robots"
           content={
-            process.env.NODE_ENV !== 'development'
+            isDev
               ? 'index,follow'
               : 'noindex,nofollow'
           }
@@ -17,7 +18,7 @@ export function CustomHead({ title = '', description, image, keywords }) {
         <meta
           name="googlebot"
           content={
-            process.env.NODE_ENV !== 'development'
+            isDev
               ? 'index,follow'
               : 'noindex,nofollow'
           }

--- a/env/index.js
+++ b/env/index.js
@@ -1,0 +1,1 @@
+export const isDev = process.env.NODE_ENV === 'development'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aniso",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,9 +1,10 @@
 /* eslint-disable @next/next/no-document-import-in-page */
+import { isDev } from 'env'
 import { Head, Html, Main, NextScript } from 'next/document'
 
 export default function Document() {
   return (
-    <Html lang="en" className={process.env.NODE_ENV === 'development' && 'dev'}>
+    <Html lang="en" className={isDev ? 'dev' : null}>
       <Head>
         <meta charSet="UTF-8" />
       </Head>


### PR DESCRIPTION
Just adding my two cents on this amazing project. Accessing env variables with `process.env` variables impacts on performance ([read github issue](https://github.com/nodejs/node/issues/3104)), as it involves a C-level lookup that can be slower than accessing a regular JavaScript variable.

Assigning it to a variable and exporting it makes it lookup only once. It's just a NIT.

Additionally, a super nit is the change for using `className={isDev ? 'dev' : null}` instead of `className={isDev && 'dev'}` (returning `null` instead of `false`) avoids an empty class attribute on the html tag.